### PR TITLE
fix: looser type for allowedSighash

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2210,12 +2210,7 @@ export class Transaction {
   }
 
   // Signer can be privateKey OR instance of bip32 HD stuff
-  signIdx(
-    privateKey: Signer,
-    idx: number,
-    allowedSighash?: SignatureHash[],
-    _auxRand?: Bytes
-  ): boolean {
+  signIdx(privateKey: Signer, idx: number, allowedSighash?: number[], _auxRand?: Bytes): boolean {
     this.checkInputIdx(idx);
     const input = this.inputs[idx];
     const inputType = this.inputType(input);


### PR DESCRIPTION
`SignatureHash` is the three sig hash values, a default, and the `ANYONECANPAY` modifier.

As far as I understand, the sighash can be any of the possible 6 resulting combinations `[0x01, 0x02, 0x03, 0x80, 0x81, 0x82, 0x83]`, meaning this type on `signIdx` is too strict, as say it doesn't except, say `0x82`.

In this PR I've just loosened the type, but maybe library should check for these possible 6 values, either as a type or runtime check?

Or, might it make sense to update the enum?

```ts
export enum SigHash {
  ALL = 0x01,
  NONE = 0x02,
  SINGLE = 0x03,
  ALL_ANYONECANPAY = 0x81,
  NONE_ANYONECANPAY = 0x82,
  SINGLE_ANYONECANPAY = 0x83,
}
```

cc/ @fbwoolf