### PR TITLE
Sign unknown inputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export {
 export { OP, RawTx, CompactSize, Script, ScriptNum } from './script.js';
 export { Transaction } from './transaction.js';
 export { selectUTXO } from './utxo.js';
-export { NETWORK, compareBytes as _cmpBytes, TAPROOT_UNSPENDABLE_KEY } from './utils.js';
+export { NETWORK, TEST_NETWORK, compareBytes as _cmpBytes, TAPROOT_UNSPENDABLE_KEY } from './utils.js';
 
 // Utils
 // prettier-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,12 @@ export {
 export { OP, RawTx, CompactSize, Script, ScriptNum } from './script.js';
 export { Transaction } from './transaction.js';
 export { selectUTXO } from './utxo.js';
-export { NETWORK, TEST_NETWORK, compareBytes as _cmpBytes, TAPROOT_UNSPENDABLE_KEY } from './utils.js';
+export {
+  NETWORK,
+  TEST_NETWORK,
+  compareBytes as _cmpBytes,
+  TAPROOT_UNSPENDABLE_KEY,
+} from './utils.js';
 
 // Utils
 // prettier-ignore

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -937,9 +937,13 @@ export class Transaction {
     } else if (inputType.last.type === 'wpkh') {
       inputScript = P.EMPTY;
       witness = [input.partialSig[0][1], input.partialSig[0][0]];
-    } else if (inputType.last.type === 'unknown' && !this.opts.allowUnknownInputs)
-      throw new Error('Unknown inputs not allowed');
-
+    } else if (inputType.last.type === 'unknown') {
+      if (!this.opts.allowUnknownInputs) {
+        throw new Error('Unknown inputs not allowed');
+      }
+      // Trying our best to sign what we can
+      inputScript = Script.encode([input.partialSig[0][1], input.partialSig[0][0]]);
+    }
     // Create final scripts (generic part)
     let finalScriptSig: Bytes | undefined, finalScriptWitness: Bytes[] | undefined;
     if (inputType.type.includes('wsh-')) {


### PR DESCRIPTION
When the script type is unknown the current version of the library does not try to sign the input.  In this PR the input is signed by placing the signature and public key in the input script. This is the best attempt to sign. If the input is segwit then the signature will be placed in the final witness, and if it is P2SH the signature will be placed in the sigscript.