### PR TITLE
Allow exact match of target === input amount during accumulation.

### DIFF
--- a/src/utxo.ts
+++ b/src/utxo.ts
@@ -475,7 +475,7 @@ export class _Estimator {
       inputsAmount += amount;
       res.push(idx);
       // inputsAmount is enough to cover cost of tx
-      if (!all && targetAmount + fee < inputsAmount)
+      if (!all && targetAmount + fee <= inputsAmount)
         return { indices: res, fee, weight: totalWeight, total: inputsAmount };
     }
     for (const idx of indices) {

--- a/src/utxo.ts
+++ b/src/utxo.ts
@@ -501,7 +501,7 @@ export class _Estimator {
       inputsAmount += amount;
       res.push(idx);
       // inputsAmount is enough to cover cost of tx
-      if (!all && targetAmount + fee < inputsAmount)
+      if (!all && targetAmount + fee <= inputsAmount)
         return { indices: res, fee, weight: totalWeight, total: inputsAmount };
     }
     if (all) {


### PR DESCRIPTION
Currently this example fails to create a valid selection even though the amount of sats available exactly matches the amount of sats needed.

```javascript
const privKey = hex.decode('0101010101010101010101010101010101010101010101010101010101010101');
const pubKey = secp256k1.getPublicKey(privKey, true);
const spend = btc.p2wpkh(pubKey, regtest);
const utxo = [
  {
    ...spend, 
    txid: hex.decode('0af50a00a22f74ece24c12cd667c290d3a35d48124a69f4082700589172a3aa2'),
    index: 0,
    witnessUtxo: { script: spend.script, amount: 50_000n },  // same amount
  },
];
const outputs = [
  { address: '2MvpbAgedBzJUBZWesDwdM7p3FEkBEwq3n3', amount: 50_000n }, // same amount
];

const selected = btc.selectUTXO(utxo, outputs, 'default', {
  changeAddress: 'bcrt1pea3850rzre54e53eh7suwmrwc66un6nmu9npd7eqrhd6g4lh8uqsxcxln8',
  feePerByte: 0n, // no fee to remove variability
});

// result: selected === undefined
// expectation: valid selection of utxo[0] as input
```

This PR fixes the comparison so an exact match results in a valid selection.