### PR TITLE
Add support for version 3 transactions

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -182,7 +182,7 @@ function validateOpts(opts: TxOpts) {
   if (typeof _opts.allowUnknowOutput !== 'undefined')
     opts.allowUnknownOutputs = _opts.allowUnknowOutput;
   // 0 and -1 happens in tests
-  if (![-1, 0, 1, 2].includes(_opts.version)) throw new Error(`Unknown version: ${_opts.version}`);
+  if (![-1, 0, 1, 2, 3].includes(_opts.version)) throw new Error(`Unknown version: ${_opts.version}`);
   if (typeof _opts.lockTime !== 'number') throw new Error('Transaction lock time should be number');
   P.U32LE.encode(_opts.lockTime); // Additional range checks that lockTime
   // There is no PSBT v1, and any new version will probably have fields which we don't know how to parse, which


### PR DESCRIPTION
There is nothing inherently different in version 3 transactions, but Bitcoin nodes will treat them differently when relaying and replacing. For example, version 3 transactions are able to pay for a feeless parent transaction using submitPackage.

Someone has mentioned this in issue #115.

More info on version 3 transactions: https://bitcoinops.org/en/topics/version-3-transaction-relay/