### PR TITLE
Support Pay to Anchor Output Types

### DIFF
--- a/src/payment.ts
+++ b/src/payment.ts
@@ -18,6 +18,20 @@ export type P2Ret = {
   witnessScript?: Bytes;
 };
 
+// Pay to Anchor (P2A)
+type OutP2AType = { type: 'p2a'; script: Bytes };
+const OutP2A: Coder<OptScript, OutP2AType | undefined> = {
+  encode(from: ScriptType): OutP2AType | undefined {
+    if (from.length !== 2 || from[0] !== 1 || !u.isBytes(from[1]) || hex.encode(from[1]) !== '4e73')
+      return;
+    return { type: 'p2a', script: Script.encode(from) };
+  },
+  decode: (to: OutP2AType): OptScript => {
+    if (to.type !== 'p2a') return;
+    return [1, hex.decode('4e73')];
+  },
+};
+
 // Public Key (P2PK)
 type OutPKType = { type: 'pk'; pubkey: Bytes };
 export type OptScript = ScriptType | undefined;
@@ -189,6 +203,7 @@ const OutUnknown: Coder<OptScript, OutUnknownType | undefined> = {
 // /Payments
 
 const OutScripts = [
+  OutP2A,
   OutPK,
   OutPKH,
   OutSH,
@@ -226,6 +241,7 @@ export type CustomScript = Coder<OptScript, CustomScriptOut | undefined> & {
 // We can validate this once, because of packed & coders
 export const OutScript: P.CoderType<
   NonNullable<
+    | OutP2AType
     | OutPKType
     | OutPKHType
     | OutSHType

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -254,6 +254,20 @@ should('OutScript', () => {
   }
 });
 
+should('P2A output type', () => {
+  // Test script encoding/decoding
+  const p2aScript = hex.decode('51024e73');
+  const decoded = btc.OutScript.decode(p2aScript);
+  deepStrictEqual(decoded, { type: 'p2a', script: p2aScript });
+  deepStrictEqual(hex.encode(btc.OutScript.encode(decoded)), '51024e73');
+
+  // Test invalid scripts are rejected
+  const wrong_segwit_version = hex.decode('52024e73'); // Wrong SegWit version [2]
+  deepStrictEqual(btc.OutScript.decode(wrong_segwit_version), { type: 'unknown', script: wrong_segwit_version });
+  const invalid_taproot_witness_script = hex.decode('510247e4'); // Non-P2A output signature still decoded as Taproot.
+  throws(() => btc.OutScript.decode(invalid_taproot_witness_script));
+});
+
 should('payTo API', () => {
   // cross-checked with bitcoinjs-lib manually
   const uncompressed = hex.decode(


### PR DESCRIPTION
**Issue**
In response to this issue. https://github.com/paulmillr/scure-btc-signer/issues/120 which I faced while testing and signing P2A transactions.

**Example P2A Mainnet TXN**
https://mempool.space/tx/d7da3b5ae755793ff486896e82553d841043df393f09593ec38b807dd2959c45

**Solution**
Adds support for; and tests enabling P2A (Pay to Anchor) output types that became standard in Bitcoin Core 28.0. Previously OP 1 <DATA> was always decoded with a Taproot (tr) output type and would trigger a check to see if the public key was valid. This behavior still exists but now has the P2A output signature checked first.

**Sources:**
https://github.com/bitcoin/bitcoin/blob/e7c479495509c068215b73f6df070af2d406ae15/src/script/script.cpp#L207-L222
https://github.com/bitcoin/bitcoin/pull/30352

**Applications:**
MARA Slipstream Supports Anchor Outputs