### PR TITLE
fix: spending all required indices

### DIFF
--- a/src/utxo.ts
+++ b/src/utxo.ts
@@ -408,7 +408,7 @@ export class _Estimator {
       inputsAmount += amount;
       res.add(idx);
       // inputsAmount is enough to cover cost of tx
-      if (!all && targetAmount + fee <= inputsAmount)
+      if (!all && targetAmount + fee <= inputsAmount && num >= this.requiredIndices.length)
         return { indices: Array.from(res), fee, weight: totalWeight, total: inputsAmount };
     }
     for (const idx of indices) {


### PR DESCRIPTION
I think that all required indices should be spend, even if less than all would be enough to cover the required amount for the outputs + fee. 

Minimal example, that should create 2 inputs, but only creates 1: 

```
import * as btc from "@scure/btc-signer";
import { hex } from "@scure/base";

const P2PKH_SCRIPT = hex.decode(
  "76a914168b992bcfc44050310b3a94bd0771136d0b28d188ac"
);

async function main() {
  const requiredInputs = [
    {
      txid: new Uint8Array(32).fill(0xaa),
      index: 0,
      witnessUtxo: {
        script: P2PKH_SCRIPT,
        amount: 100000000n,
      },
    },
    {
      txid: new Uint8Array(32).fill(0xbb),
      index: 0,
      witnessUtxo: {
        script: P2PKH_SCRIPT,
        amount: 7000n,
      },
    },
  ];

  const nonRequiredInput = {
    txid: new Uint8Array(32).fill(0xcc),
    index: 0,
    witnessUtxo: {
      script: P2PKH_SCRIPT,
      amount: 5000n,
    },
  };


  const outputs = [
    {
      address: "134D6gYy8DsR5m4416BnmgASuMBqKvogQh",
      amount: 1000n,
    },
  ];

  const selection = btc.selectUTXO([nonRequiredInput], outputs, "default", {
    requiredInputs: requiredInputs,
    feePerByte: 1n,
    allowSameUtxo: false,
    allowLegacyWitnessUtxo: true,
    disableScriptCheck: true,
    createTx: false, // no need to finalize a Transaction
    changeAddress: "134D6gYy8DsR5m4416BnmgASuMBqKvogQh",
  });

  if (!selection) {
    console.log("No selection was made.");
    return;
  }

  console.log(`\nSelection result:\n----------------`);
  console.log(`Fee: ${selection.fee} sat`);
  console.log("Included inputs:");
  selection.inputs.forEach((inp, idx) => {
    const { txid, index, witnessUtxo } = inp;
    console.log(
      `  #${idx}: txid=${hex.encode(txid!)} index=${index!} amount=${
        witnessUtxo?.amount
      }`
    );
  });
}

main().catch((err) => console.error(err));
```

