### PR TITLE
allowUnknownVersion flag for non-standard tx versions

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -66,6 +66,8 @@ export interface TxOpts {
   lockTime?: number;
   PSBTVersion?: number;
   // Flags
+  // Allow non-standard transaction version
+  allowUnknownVersion?: boolean;
   // Allow output scripts to be unknown scripts (probably unspendable)
   /** @deprecated Use `allowUnknownOutputs` */
   allowUnknowOutput?: boolean;
@@ -190,9 +192,6 @@ function validateOpts(opts: TxOpts): Readonly<TxOpts> {
     opts.allowUnknownInputs = _opts.allowUnknowInput;
   if (typeof _opts.allowUnknowOutput !== 'undefined')
     opts.allowUnknownOutputs = _opts.allowUnknowOutput;
-  // 0 and -1 happens in tests
-  if (![-1, 0, 1, 2, 3].includes(_opts.version))
-    throw new Error(`Unknown version: ${_opts.version}`);
   if (typeof _opts.lockTime !== 'number') throw new Error('Transaction lock time should be number');
   P.U32LE.encode(_opts.lockTime); // Additional range checks that lockTime
   // There is no PSBT v1, and any new version will probably have fields which we don't know how to parse, which
@@ -201,6 +200,7 @@ function validateOpts(opts: TxOpts): Readonly<TxOpts> {
     throw new Error(`Unknown PSBT version ${_opts.PSBTVersion}`);
   // Flags
   for (const k of [
+    'allowUnknownVersion',
     'allowUnknownOutputs',
     'allowUnknownInputs',
     'disableScriptCheck',
@@ -213,6 +213,13 @@ function validateOpts(opts: TxOpts): Readonly<TxOpts> {
     if (typeof v !== 'boolean')
       throw new Error(`Transation options wrong type: ${k}=${v} (${typeof v})`);
   }
+  // 0 and -1 happens in tests
+  if (
+    _opts.allowUnknownVersion
+      ? typeof _opts.version === 'number'
+      : ![-1, 0, 1, 2, 3].includes(_opts.version)
+  )
+    throw new Error(`Unknown version: ${_opts.version}`);
   if (_opts.customScripts !== undefined) {
     const cs = _opts.customScripts;
     if (!Array.isArray(cs)) {


### PR DESCRIPTION
Some transactions use non-standard transaction version, which makes the parsing fail (as the library enforces the transaction version to be in [-1, 0, 1, 2, 3]). This solves the issue by introducing allowUnknownVersion flag (by example of the allowUnknownInputs), which then allows the transaction version to be any number (maybe the u32 limit should also be enforced there?).

Examples of such transactions:
Mainnet:
https://mempool.space/tx/889d4fed1ec4a775d02082b5ff727f48d93013469db709d8d435e15b173118f3
Testnet4:
https://mempool.space/testnet4/tx/f72c5571860f0d84725312f499f5f49facaee3a0dca1ddd808ff1e6f7812dcae
https://mempool.space/testnet4/tx/8e97c5b93da734f7b7d94f7a57dc4b3f9a5087d533a0e5c9ce0c3b17f569f50e