### PR TITLE
do not throw Transaction.id if not finalized

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -635,11 +635,9 @@ export class Transaction {
   }
 
   get hash(): string {
-    if (!this.isFinal) throw new Error('Transaction is not finalized');
     return hex.encode(u.sha256x2(this.toBytes(true)));
   }
   get id(): string {
-    if (!this.isFinal) throw new Error('Transaction is not finalized');
     return hex.encode(u.sha256x2(this.toBytes(true)).reverse());
   }
   // Input stuff


### PR DESCRIPTION
This PR removes the final checks in `Transaction.id` and `Transaction.hash` getters. 

Sometimes, you want to be able to compute a transaction txid before signing it. For instance, when you want to craft a tx bumping P2A output without signing the parent tx. I do think it should be possible to use the `id` getter instead of `hex.encode(sha256x2(tx.toBytes(true)).reverse())`.

@paulmillr please review