### PR TITLE
Fix typo in `_Estimator.getSatoshi` argument name

### DIFF
--- a/src/utxo.ts
+++ b/src/utxo.ts
@@ -353,8 +353,8 @@ export class _Estimator {
       return compareBytes(scripts[a], scripts[b]);
     });
   }
-  private getSatoshi(weigth: number) {
-    return this.opts.feePerByte * BigInt(toVsize(weigth));
+  private getSatoshi(weight: number) {
+    return this.opts.feePerByte * BigInt(toVsize(weight));
   }
 
   // Sort by value instead of amount


### PR DESCRIPTION
This PR fixes a typo in the `_Estimator.getSatoshi` method's argument name. It should be `weight`, not `weigth`.